### PR TITLE
Use explicit relative imports to work with Python 3

### DIFF
--- a/random_name/__init__.py
+++ b/random_name/__init__.py
@@ -1,6 +1,6 @@
 import random
 
-from dictionaries import ADJECTIVES, COLORS, ANIMALS
+from .dictionaries import ADJECTIVES, COLORS, ANIMALS
 
 
 def generate_name(repeat_parts=False, separator='-',

--- a/random_name/dictionaries/__init__.py
+++ b/random_name/dictionaries/__init__.py
@@ -1,3 +1,3 @@
-from adjectives import ADJECTIVES
-from colors import COLORS
-from animals import ANIMALS
+from .adjectives import ADJECTIVES
+from .colors import COLORS
+from .animals import ANIMALS


### PR DESCRIPTION
Had some import issues when using Python 3 so adding the `.` prefix to relative imports fixed it